### PR TITLE
Publish retry message when storing document fails

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,4 @@ AWS_ACCESS_KEY_ID=123
 AWS_SECRET_KEY=xyz
 AWS_BUCKET_NAME=judgments-original-versions
 AWS_ENDPOINT_URL=http://host.docker.internal:4566
+SQS_QUEUE_URL=http://172.17.0.2:4566/000000000000/retry-queue

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     image: localstack/localstack
     network_mode: bridge
     environment:
-      SERVICES: lambda,sns,s3
+      SERVICES: lambda,sns,s3,sqs
       DEBUG: 1
     ports:
       - 4566:4566

--- a/lambda_function.py
+++ b/lambda_function.py
@@ -3,7 +3,8 @@ import json
 
 from typing import Union, Dict, List, Tuple
 
-import boto3 as boto3
+import boto3
+from boto3.session import Session
 import urllib3
 import tarfile
 import xml.etree.ElementTree as ET
@@ -41,9 +42,7 @@ def store_metadata(uri: str, metadata: Dict[str, Union[str, dict, List[dict]]]) 
     api_client.set_property(uri, name="contact-email", value=metadata["bagit-info"]["Contact-Email"])
 
 
-def store_original_document(original_document, uri):
-    session = boto3.session.Session(aws_access_key_id=os.getenv('AWS_ACCESS_KEY_ID'),
-                                    aws_secret_access_key=os.getenv('AWS_SECRET_KEY'))
+def store_original_document(original_document, uri, session: Session):
     s3 = session.client('s3', endpoint_url=os.getenv('AWS_ENDPOINT_URL'))
     filename = f'{uri}.docx'
 
@@ -57,49 +56,72 @@ def store_original_document(original_document, uri):
         print('Credentials not available')
 
 
+def send_retry_message(original_message: Dict[str, Union[str, int]], session: Session) -> None:
+    sqs = session.client('sqs', endpoint_url=os.getenv('AWS_ENDPOINT_URL'))
+    retry_message = {
+        "consignment-reference": original_message["consignment-reference"],
+        "s3-folder-url": "",
+        "consignment-type": original_message["consignment-type"],
+        "number-of-retries": int(original_message["number-of-retries"]) + 1
+    }
+    sqs.send_message(
+        QueueUrl=os.getenv('SQS_QUEUE_URL'),
+        MessageBody=json.dumps(retry_message)
+    )
+
+
 def handler(event, context):
     decoder = json.decoder.JSONDecoder()
     message = decoder.decode(event['Records'][0]['Sns']['Message'])
     consignment_reference = message["consignment-reference"]
 
-    # Retrieve tar file from S3
-    http = urllib3.PoolManager()
-    file = http.request('GET', message["s3-folder-url"])
+    session = boto3.session.Session(aws_access_key_id=os.getenv('AWS_ACCESS_KEY_ID'),
+                                    aws_secret_access_key=os.getenv('AWS_SECRET_KEY'))
+    try:
+        # Retrieve tar file from S3
+        http = urllib3.PoolManager()
+        file = http.request('GET', message["s3-folder-url"])
 
-    # Store it in the /tmp directory
-    filename = os.path.join("/tmp", f'{consignment_reference}.tar.gz')
-    with open(filename, 'wb') as out:
-        out.write(file.data)
-        out.close()
+        # Store it in the /tmp directory
+        filename = os.path.join("/tmp", f'{consignment_reference}.tar.gz')
+        with open(filename, 'wb') as out:
+            out.write(file.data)
+            out.close()
 
-    # Extract the judgment XML
-    tar = tarfile.open(filename, mode='r')
-    xml_file = tar.extractfile(f'{consignment_reference}/{consignment_reference}.xml')
+        # Extract the judgment XML
+        tar = tarfile.open(filename, mode='r')
+        xml_file = tar.extractfile(f'{consignment_reference}/{consignment_reference}.xml')
 
-    te_meta = tar.extractfile(f'{consignment_reference}/te-meta.json')
-    uri = extract_uri(te_meta.read().decode('utf-8'))
+        te_meta = tar.extractfile(f'{consignment_reference}/te-meta.json')
+        uri = extract_uri(te_meta.read().decode('utf-8'))
 
-    te_metadata_file = tar.extractfile(f'{consignment_reference}/te-metadata.json')
-    metadata = decoder.decode(te_metadata_file.read().decode('utf-8'))
+        te_metadata_file = tar.extractfile(f'{consignment_reference}/te-metadata.json')
+        metadata = decoder.decode(te_metadata_file.read().decode('utf-8'))
 
-    if xml_file and uri:
-        contents = xml_file.read()
+        if xml_file and uri:
+            contents = xml_file.read()
 
-        xml = ET.XML(contents)
+            xml = ET.XML(contents)
 
-        try:
-            api_client.get_judgment_xml(uri, show_unpublished=True)
-            api_client.save_judgment_xml(uri, xml)
-            print(f'Updated judgment {uri}')
-        except MarklogicCommunicationError:
-            api_client.insert_judgment_xml(uri, xml)
-            print(f'Inserted judgment {uri}')
+            try:
+                api_client.get_judgment_xml(uri, show_unpublished=True)
+                api_client.save_judgment_xml(uri, xml)
+                print(f'Updated judgment {uri}')
+            except MarklogicCommunicationError:
+                api_client.insert_judgment_xml(uri, xml)
+                print(f'Inserted judgment {uri}')
 
-        # Store metadata
-        store_metadata(uri, metadata)
+            # Store metadata
+            store_metadata(uri, metadata)
 
-    original_document = tar.extractfile(f'{consignment_reference}/{consignment_reference}.docx')
-    if original_document:
-        store_original_document(original_document, uri)
+            original_document = tar.extractfile(f'{consignment_reference}/{consignment_reference}.docx')
+            if original_document:
+                store_original_document(original_document, uri, session)
+
+    except BaseException:
+        # Send retry message to sqs
+        send_retry_message(message, session)
+        # Raise error up to ensure it's logged
+        raise
 
     return message

--- a/scripts/setup-localstack.sh
+++ b/scripts/setup-localstack.sh
@@ -9,7 +9,7 @@ awslocal lambda create-function \
   --zip-file fileb://dist/lambda.zip \
   --handler lambda_function.handler \
   --runtime python3.9 \
-  --environment "Variables={MARKLOGIC_HOST=$MARKLOGIC_HOST,MARKLOGIC_USER=$MARKLOGIC_USER,MARKLOGIC_PASSWORD=$MARKLOGIC_PASSWORD,AWS_BUCKET_NAME=$AWS_BUCKET_NAME,AWS_SECRET_KEY=$AWS_SECRET_KEY,AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID,AWS_ENDPOINT_URL=$AWS_ENDPOINT_URL}" \
+  --environment "Variables={MARKLOGIC_HOST=$MARKLOGIC_HOST,MARKLOGIC_USER=$MARKLOGIC_USER,MARKLOGIC_PASSWORD=$MARKLOGIC_PASSWORD,AWS_BUCKET_NAME=$AWS_BUCKET_NAME,AWS_SECRET_KEY=$AWS_SECRET_KEY,AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID,AWS_ENDPOINT_URL=$AWS_ENDPOINT_URL,SQS_QUEUE_URL=$SQS_QUEUE_URL}" \
   --role arn:aws:iam::000000000000:role/lambda-role \
 
 awslocal sns create-topic \
@@ -28,3 +28,5 @@ awslocal s3api create-bucket \
   --bucket judgments-original-versions
 
 awslocal s3 cp aws_examples/s3/te-editorial-out-int/TDR-2022-DNWR.tar.gz s3://te-editorial-out-int
+
+awslocal sqs create-queue --queue-name retry-queue


### PR DESCRIPTION
Create SQS queue inside Localstack to publish failed parsed document messages.

Inside the Lambda function, push a retry message to the queue when an exception occurs during processing, incrementing the "number-of-retries" counter by 1.